### PR TITLE
fix(profiles): multisign transaction payload

### DIFF
--- a/packages/profiles/source/wallet-transaction.service.ts
+++ b/packages/profiles/source/wallet-transaction.service.ts
@@ -302,7 +302,7 @@ export class TransactionService implements ITransactionService {
 					amount: transactionData.amount.toString(),
 					fee: transactionData.fee.toString(),
 					nonce: transactionData.nonce.toString(),
-				})
+				});
 		}
 
 		if (result.accepted.includes(transaction.id())) {

--- a/packages/profiles/source/wallet-transaction.service.ts
+++ b/packages/profiles/source/wallet-transaction.service.ts
@@ -292,10 +292,17 @@ export class TransactionService implements ITransactionService {
 		if (this.canBeBroadcasted(id)) {
 			result = await this.#wallet.client().broadcast([transaction.data()]);
 		} else if (transaction.isMultiSignatureRegistration() || transaction.usesMultiSignature()) {
+			const transactionData = transaction.data().data();
+
 			result = await this.#wallet
 				.coin()
 				.multiSignature()
-				.broadcast(JSON.parse(JSON.stringify(transaction.data().data(), null, 4)));
+				.broadcast({
+					...JSON.parse(JSON.stringify(transactionData, null, 4)),
+					amount: transactionData.amount.toString(),
+					fee: transactionData.fee.toString(),
+					nonce: transactionData.nonce.toString(),
+				})
 		}
 
 		if (result.accepted.includes(transaction.id())) {

--- a/packages/profiles/source/wallet-transaction.service.ts
+++ b/packages/profiles/source/wallet-transaction.service.ts
@@ -292,16 +292,16 @@ export class TransactionService implements ITransactionService {
 		if (this.canBeBroadcasted(id)) {
 			result = await this.#wallet.client().broadcast([transaction.data()]);
 		} else if (transaction.isMultiSignatureRegistration() || transaction.usesMultiSignature()) {
-			const transactionData = transaction.data().data();
+			const { amount, fee, nonce, ...restOfThePayload } = transaction.data().data();
 
 			result = await this.#wallet
 				.coin()
 				.multiSignature()
 				.broadcast({
-					...JSON.parse(JSON.stringify(transactionData, null, 4)),
-					amount: transactionData.amount.toString(),
-					fee: transactionData.fee.toString(),
-					nonce: transactionData.nonce.toString(),
+					...JSON.parse(JSON.stringify(restOfThePayload, undefined, 4)),
+					amount: amount.toString(),
+					fee: fee.toString(),
+					nonce: nonce.toString(),
 				});
 		}
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Once updated on DW should fix https://github.com/ArkEcosystem/payvo-wallet/issues/990

Currently, when it tries to send a request in `packages/ark/source/multi-signature.service.ts@#post` it throws an exception with a `bignumber keyword validation` error for the nonce, the reason is that the payload is not created properly because the values for `nonce`, `amount` and `fee` are parsed as a regular plain objects which explains the validation error (those values are BigNumber instances before parsed with JSON.stringify/parse)

I am sending those values as strings since I think is  the safest way to send a big number without losing data but may require a second opinion from someone more familiarized with the SDK (I cant send theme as plain big number since it throws a JSON encoding exception)


## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
