### PR TITLE
fix(ark): scan method giving incomplete data

### DIFF
--- a/packages/ark/source/ledger.service.ts
+++ b/packages/ark/source/ledger.service.ts
@@ -1,5 +1,5 @@
 import { ARKTransport } from "@arkecosystem/ledger-transport";
-import { Collections,Contracts, IoC, Services } from "@payvo/sdk";
+import { Collections, Contracts, IoC, Services } from "@payvo/sdk";
 import { BIP44, HDKey } from "@payvo/sdk-cryptography";
 import { Buffer } from "buffer";
 
@@ -93,7 +93,7 @@ export class LedgerService extends Services.AbstractLedgerService {
 				const batchWalletsCollection = collection.items();
 
 				if (options?.onProgress !== undefined) {
-					for (const item of batchWalletsCollection)  {
+					for (const item of batchWalletsCollection) {
 						options.onProgress(item);
 					}
 				}
@@ -140,20 +140,20 @@ export class LedgerService extends Services.AbstractLedgerService {
 				const batchWalletsCollection = collections.flatMap((collection) => collection.items());
 
 				if (options?.onProgress !== undefined) {
-					for (const item of batchWalletsCollection)  {
+					for (const item of batchWalletsCollection) {
 						options.onProgress(item);
 					}
 				}
 
 				walletsCollection.push(...batchWalletsCollection);
 
-				hasMore = collections.some(collection => collection.isNotEmpty());
+				hasMore = collections.some((collection) => collection.isNotEmpty());
 			}
 
 			page++;
 		} while (hasMore);
 
-		return this.mapPathsToWallets(addressCache, walletsCollection)
+		return this.mapPathsToWallets(addressCache, walletsCollection);
 	}
 
 	public override async isNanoS(): Promise<boolean> {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Related to https://github.com/ArkEcosystem/payvo-wallet/issues/1149 but can be closed until deps are updated in the desktop wallet.

Note that this issue happens because, in the step where we map the ledger wallets, not all the wallets are being passed to the `mapPathsToWallets` method because we don't have all yet in some cases (wallets are loaded in a loop). I let you know this because is not really easy to replicate the issue so maybe you can only focus on the code and ensure the new logic is correct and everything still works as expected (only if you have trouble in replicating the problem).

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
