### PR TITLE
chore(ark): add SXP networks

### DIFF
--- a/packages/ark/source/link.service.test.ts
+++ b/packages/ark/source/link.service.test.ts
@@ -1,5 +1,5 @@
-import { describe } from "@payvo/sdk-test";
 import { Services } from "@payvo/sdk";
+import { describe } from "@payvo/sdk-test";
 
 import { createService } from "../test/mocking";
 
@@ -7,13 +7,13 @@ describe("LinkService", ({ assert, it, nock, loader }) => {
 	it("should generate a link for a block on a [ark.mainnet] explorer", async () => {
 		const subject = await createService(Services.AbstractLinkService, "ark.mainnet");
 
-		assert.is(subject.block("id"), "https://explorer.ark.io/block/id");
+		assert.is(subject.block("id"), "https://explorer.ark.io/blocks/id");
 	});
 
 	it("should generate a link for a transaction on a [ark.mainnet] explorer", async () => {
 		const subject = await createService(Services.AbstractLinkService, "ark.mainnet");
 
-		assert.is(subject.transaction("id"), "https://explorer.ark.io/transaction/id");
+		assert.is(subject.transaction("id"), "https://explorer.ark.io/transactions/id");
 	});
 
 	it("should generate a link for a wallet on a [ark.mainnet] explorer", async () => {
@@ -25,13 +25,13 @@ describe("LinkService", ({ assert, it, nock, loader }) => {
 	it("should generate a link for a block on a [ark.devnet] explorer", async () => {
 		const subject = await createService(Services.AbstractLinkService, "ark.devnet");
 
-		assert.is(subject.block("id"), "https://dexplorer.ark.io/block/id");
+		assert.is(subject.block("id"), "https://dexplorer.ark.io/blocks/id");
 	});
 
 	it("should generate a link for a transaction on a [ark.devnet] explorer", async () => {
 		const subject = await createService(Services.AbstractLinkService, "ark.devnet");
 
-		assert.is(subject.transaction("id"), "https://dexplorer.ark.io/transaction/id");
+		assert.is(subject.transaction("id"), "https://dexplorer.ark.io/transactions/id");
 	});
 
 	it("should generate a link for a wallet on a [ark.devnet] explorer", async () => {
@@ -128,5 +128,41 @@ describe("LinkService", ({ assert, it, nock, loader }) => {
 		const subject = await createService(Services.AbstractLinkService, "bpl.mainnet");
 
 		assert.is(subject.wallet("id"), "https://explorer.blockpool.io/#/wallets/id");
+	});
+
+	it("should generate a link for a block on a [sxp.mainnet] explorer", async () => {
+		const subject = await createService(Services.AbstractLinkService, "sxp.mainnet");
+
+		assert.is(subject.block("id"), "https://explorer.solar.org/blocks/id");
+	});
+
+	it("should generate a link for a transaction on a [sxp.mainnet] explorer", async () => {
+		const subject = await createService(Services.AbstractLinkService, "sxp.mainnet");
+
+		assert.is(subject.transaction("id"), "https://explorer.solar.org/transactions/id");
+	});
+
+	it("should generate a link for a wallet on a [sxp.mainnet] explorer", async () => {
+		const subject = await createService(Services.AbstractLinkService, "sxp.mainnet");
+
+		assert.is(subject.wallet("id"), "https://explorer.solar.org/wallets/id");
+	});
+
+	it("should generate a link for a block on a [sxp.testnet] explorer", async () => {
+		const subject = await createService(Services.AbstractLinkService, "sxp.testnet");
+
+		assert.is(subject.block("id"), "https://texplorer.solar.org/blocks/id");
+	});
+
+	it("should generate a link for a transaction on a [sxp.testnet] explorer", async () => {
+		const subject = await createService(Services.AbstractLinkService, "sxp.testnet");
+
+		assert.is(subject.transaction("id"), "https://texplorer.solar.org/transactions/id");
+	});
+
+	it("should generate a link for a wallet on a [sxp.testnet] explorer", async () => {
+		const subject = await createService(Services.AbstractLinkService, "sxp.testnet");
+
+		assert.is(subject.wallet("id"), "https://texplorer.solar.org/wallets/id");
 	});
 });

--- a/packages/ark/source/manifest.ts
+++ b/packages/ark/source/manifest.ts
@@ -3,6 +3,8 @@ import ArkMainnet from "./networks/ark.mainnet.js";
 import BindMainnet from "./networks/bind.mainnet.js";
 import BindTestnet from "./networks/bind.testnet.js";
 import BplMainnet from "./networks/bpl.mainnet.js";
+import SxpMainnet from "./networks/sxp.mainnet.js";
+import SxpTestnet from "./networks/sxp.testnet.js";
 import XqrMainnet from "./networks/xqr.mainnet.js";
 import XqrTestnet from "./networks/xqr.testnet.js";
 
@@ -14,6 +16,8 @@ export const manifest = {
 		"bind.mainnet": BindMainnet,
 		"bind.testnet": BindTestnet,
 		"bpl.mainnet": BplMainnet,
+		"sxp.mainnet": SxpMainnet,
+		"sxp.testnet": SxpTestnet,
 		"xqr.mainnet": XqrMainnet,
 		"xqr.testnet": XqrTestnet,
 	},

--- a/packages/ark/source/networks/bind.testnet.ts
+++ b/packages/ark/source/networks/bind.testnet.ts
@@ -1,6 +1,6 @@
 import { Networks } from "@payvo/sdk";
 
-import { explorer, featureFlags, importMethods, transactions } from "./shared.js";
+import { featureFlags, importMethods, transactions } from "./shared.js";
 
 const network: Networks.NetworkManifest = {
 	coin: "Compendia",
@@ -12,7 +12,11 @@ const network: Networks.NetworkManifest = {
 		symbol: "Tß",
 		ticker: "TBIND",
 	},
-	explorer,
+	explorer: {
+		block: "block/{0}",
+		transaction: "transaction/{0}",
+		wallet: "wallets/{0}",
+	},
 	featureFlags: {
 		...featureFlags,
 		Transaction: [

--- a/packages/ark/source/networks/shared.ts
+++ b/packages/ark/source/networks/shared.ts
@@ -87,7 +87,7 @@ export const featureFlags: Networks.NetworkManifestFeatureFlags = {
 };
 
 export const explorer: Networks.NetworkManifestExplorer = {
-	block: "block/{0}",
-	transaction: "transaction/{0}",
+	block: "blocks/{0}",
+	transaction: "transactions/{0}",
 	wallet: "wallets/{0}",
 };

--- a/packages/ark/source/networks/sxp.mainnet.ts
+++ b/packages/ark/source/networks/sxp.mainnet.ts
@@ -1,60 +1,47 @@
 import { Networks } from "@payvo/sdk";
 
-import { featureFlags, importMethods, transactions } from "./shared.js";
+import { explorer, featureFlags, importMethods, transactions } from "./shared.js";
 
 const network: Networks.NetworkManifest = {
-	coin: "Compendia",
+	coin: "Solar",
 	constants: {
-		slip44: 543,
+		slip44: 3333,
 	},
 	currency: {
 		decimals: 8,
-		symbol: "ß",
-		ticker: "BIND",
+		symbol: "SXP",
+		ticker: "SXP",
 	},
-	explorer: {
-		block: "block/{0}",
-		transaction: "transaction/{0}",
-		wallet: "wallets/{0}",
-	},
+	explorer,
 	featureFlags: {
 		...featureFlags,
 		Transaction: [
 			"delegateRegistration",
 			"delegateResignation",
 			"estimateExpiration",
-			"multiPayment.musig",
 			"multiPayment",
-			"multiSignature.musig",
-			"multiSignature",
 			"secondSignature",
-			"transfer.musig",
 			"transfer",
-			"vote.musig",
 			"vote",
 		],
 	},
 	governance: {
-		delegateCount: 47,
+		delegateCount: 53,
 		method: "split",
 		votesPerTransaction: 1,
 		votesPerWallet: 1,
 	},
 	hosts: [
 		{
-			host: "https://apis.compendia.org/api",
+			host: "https://sxp.mainnet.sh/api",
 			type: "full",
 		},
 		{
-			host: "https://bind-live-musig.payvo.com",
-			type: "musig",
-		},
-		{
-			host: "https://bindscan.io",
+			host: "https://explorer.solar.org",
 			type: "explorer",
 		},
 	],
-	id: "bind.mainnet",
+	id: "sxp.mainnet",
 	importMethods,
 	meta: {
 		fastDelegateSync: true,
@@ -63,10 +50,9 @@ const network: Networks.NetworkManifest = {
 	transactions: {
 		...transactions,
 		fees: {
-			ticker: "BIND",
-			type: "static",
+			ticker: "SXP",
+			type: "dynamic",
 		},
-		memo: false,
 		multiPaymentRecipients: 128,
 	},
 	type: "live",

--- a/packages/ark/source/networks/sxp.testnet.ts
+++ b/packages/ark/source/networks/sxp.testnet.ts
@@ -1,75 +1,61 @@
 import { Networks } from "@payvo/sdk";
 
-import { featureFlags, importMethods, transactions } from "./shared.js";
+import { explorer, featureFlags, importMethods, transactions } from "./shared.js";
 
 const network: Networks.NetworkManifest = {
-	coin: "Compendia",
+	coin: "Solar",
 	constants: {
-		slip44: 543,
+		slip44: 1,
 	},
 	currency: {
 		decimals: 8,
-		symbol: "ß",
-		ticker: "BIND",
+		symbol: "tSXP",
+		ticker: "tSXP",
 	},
-	explorer: {
-		block: "block/{0}",
-		transaction: "transaction/{0}",
-		wallet: "wallets/{0}",
-	},
+	explorer,
 	featureFlags: {
 		...featureFlags,
 		Transaction: [
 			"delegateRegistration",
 			"delegateResignation",
 			"estimateExpiration",
-			"multiPayment.musig",
 			"multiPayment",
-			"multiSignature.musig",
-			"multiSignature",
 			"secondSignature",
-			"transfer.musig",
 			"transfer",
-			"vote.musig",
 			"vote",
 		],
 	},
 	governance: {
-		delegateCount: 47,
+		delegateCount: 53,
 		method: "split",
 		votesPerTransaction: 1,
 		votesPerWallet: 1,
 	},
 	hosts: [
 		{
-			host: "https://apis.compendia.org/api",
+			host: "https://sxp1.testnet.sh/api",
 			type: "full",
 		},
 		{
-			host: "https://bind-live-musig.payvo.com",
-			type: "musig",
-		},
-		{
-			host: "https://bindscan.io",
+			host: "https://texplorer.solar.org",
 			type: "explorer",
 		},
 	],
-	id: "bind.mainnet",
+	id: "sxp.testnet",
 	importMethods,
 	meta: {
 		fastDelegateSync: true,
 	},
-	name: "Mainnet",
+	name: "Testnet",
 	transactions: {
 		...transactions,
 		fees: {
-			ticker: "BIND",
-			type: "static",
+			ticker: "tSXP",
+			type: "dynamic",
 		},
-		memo: false,
 		multiPaymentRecipients: 128,
 	},
-	type: "live",
+	type: "test",
 };
 
 export default network;


### PR DESCRIPTION
Adds configurations from https://github.com/Solar-network/desktop-wallet/blob/master/rebrand/node_modules/%40payvo/sdk-ark/distribution/cjs/networks/sxp.mainnet.js and https://github.com/Solar-network/desktop-wallet/blob/master/rebrand/node_modules/%40payvo/sdk-ark/distribution/cjs/networks/tsxp.testnet.js