### PR TITLE
chore(ark): adjust SXP network configs

### DIFF
--- a/packages/ark/source/networks/sxp.mainnet.ts
+++ b/packages/ark/source/networks/sxp.mainnet.ts
@@ -19,6 +19,7 @@ const network: Networks.NetworkManifest = {
 			"delegateRegistration",
 			"delegateResignation",
 			"estimateExpiration",
+			"ipfs",
 			"multiPayment",
 			"secondSignature",
 			"transfer",
@@ -27,7 +28,6 @@ const network: Networks.NetworkManifest = {
 	},
 	governance: {
 		delegateCount: 53,
-		method: "split",
 		votesPerTransaction: 1,
 		votesPerWallet: 1,
 	},
@@ -53,7 +53,7 @@ const network: Networks.NetworkManifest = {
 			ticker: "SXP",
 			type: "dynamic",
 		},
-		multiPaymentRecipients: 128,
+		multiPaymentRecipients: 256,
 	},
 	type: "live",
 };

--- a/packages/ark/source/networks/sxp.testnet.ts
+++ b/packages/ark/source/networks/sxp.testnet.ts
@@ -19,6 +19,7 @@ const network: Networks.NetworkManifest = {
 			"delegateRegistration",
 			"delegateResignation",
 			"estimateExpiration",
+			"ipfs",
 			"multiPayment",
 			"secondSignature",
 			"transfer",
@@ -27,7 +28,6 @@ const network: Networks.NetworkManifest = {
 	},
 	governance: {
 		delegateCount: 53,
-		method: "split",
 		votesPerTransaction: 1,
 		votesPerWallet: 1,
 	},
@@ -53,7 +53,7 @@ const network: Networks.NetworkManifest = {
 			ticker: "tSXP",
 			type: "dynamic",
 		},
-		multiPaymentRecipients: 128,
+		multiPaymentRecipients: 256,
 	},
 	type: "test",
 };

--- a/packages/sdk/source/network-repository.test.ts
+++ b/packages/sdk/source/network-repository.test.ts
@@ -7,7 +7,7 @@ describe("NetworkRepository", ({ assert, beforeEach, it, nock, loader }) => {
 	beforeEach((context) => (context.subject = new NetworkRepository(manifest.networks)));
 
 	it("should get all values", (context) => {
-		assert.length(Object.keys(context.subject.all()), 8);
+		assert.length(Object.keys(context.subject.all()), 10);
 	});
 
 	it("should set, get and forget a network", (context) => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Adjusts the SXP network configs:

- remove `split` vote method to allow single transaction vote switches
- enable the IPFS transaction type
- increase multipayment limit to 256

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
