### PR TITLE
refactor(profiles): include network id in wallet lookup of transaction aggregate

### DIFF
--- a/packages/profiles/source/transaction.aggregate.test.ts
+++ b/packages/profiles/source/transaction.aggregate.test.ts
@@ -1,5 +1,4 @@
 import { describe } from "@payvo/sdk-test";
-import { Contracts } from ".";
 
 import { identity } from "../test/fixtures/identity";
 import { bootContainer, importByMnemonic } from "../test/mocking";
@@ -7,11 +6,12 @@ import { bootContainer, importByMnemonic } from "../test/mocking";
 import { Profile } from "./profile";
 import { TransactionAggregate } from "./transaction.aggregate";
 import { ExtendedConfirmedTransactionDataCollection } from "./transaction.collection";
+import { IReadWriteWallet } from "./wallet.contract";
 
 describe("TransactionAggregate", ({ each, loader, afterEach, beforeAll, beforeEach, nock, assert, stub, spy, it }) => {
 	const datasets = ["all", "sent", "received"];
 
-	let wallet: Contracts.IReadWriteWallet;
+	let wallet: IReadWriteWallet;
 
 	beforeAll(async (context) => {
 		bootContainer();

--- a/packages/profiles/source/transaction.aggregate.ts
+++ b/packages/profiles/source/transaction.aggregate.ts
@@ -60,9 +60,9 @@ export class TransactionAggregate implements ITransactionAggregate {
 		delete query.identifiers;
 
 		for (const syncedWallet of syncedWallets) {
-			requests[`${syncedWallet.networkId()}.${syncedWallet.id()}`] = new Promise((resolve, reject) => {
+			requests[syncedWallet.id()] = new Promise((resolve, reject) => {
 				const lastResponse: HistoryWallet =
-					this.#history[method][`${syncedWallet.networkId()}.${syncedWallet.id()}`];
+					this.#history[method][syncedWallet.id()];
 
 				if (lastResponse && !lastResponse.hasMorePages()) {
 					return reject(

--- a/packages/profiles/source/transaction.aggregate.ts
+++ b/packages/profiles/source/transaction.aggregate.ts
@@ -61,8 +61,7 @@ export class TransactionAggregate implements ITransactionAggregate {
 
 		for (const syncedWallet of syncedWallets) {
 			requests[syncedWallet.id()] = new Promise((resolve, reject) => {
-				const lastResponse: HistoryWallet =
-					this.#history[method][syncedWallet.id()];
+				const lastResponse: HistoryWallet = this.#history[method][syncedWallet.id()];
 
 				if (lastResponse && !lastResponse.hasMorePages()) {
 					return reject(

--- a/packages/profiles/source/transaction.aggregate.ts
+++ b/packages/profiles/source/transaction.aggregate.ts
@@ -60,8 +60,9 @@ export class TransactionAggregate implements ITransactionAggregate {
 		delete query.identifiers;
 
 		for (const syncedWallet of syncedWallets) {
-			requests[syncedWallet.id()] = new Promise((resolve, reject) => {
-				const lastResponse: HistoryWallet = this.#history[method][syncedWallet.id()];
+			requests[`${syncedWallet.networkId()}.${syncedWallet.id()}`] = new Promise((resolve, reject) => {
+				const lastResponse: HistoryWallet =
+					this.#history[method][`${syncedWallet.networkId()}.${syncedWallet.id()}`];
 
 				if (lastResponse && !lastResponse.hasMorePages()) {
 					return reject(
@@ -113,14 +114,16 @@ export class TransactionAggregate implements ITransactionAggregate {
 			.filter((wallet: IReadWriteWallet) => {
 				const match =
 					identifiers.length === 0 ||
-					identifiers.some(({ type, value }: Services.WalletIdentifier) => {
+					identifiers.some(({ type, value, networkId }: Services.WalletIdentifier) => {
+						const networkMatch = networkId ? networkId === wallet.networkId() : true;
+
 						if (type === "address") {
-							return value === wallet.address();
+							return networkMatch && value === wallet.address();
 						}
 
 						/* istanbul ignore else */
 						if (type === "extendedPublicKey") {
-							return value === wallet.publicKey();
+							return networkMatch && value === wallet.publicKey();
 						}
 
 						/* istanbul ignore next */

--- a/packages/sdk/source/client.contract.ts
+++ b/packages/sdk/source/client.contract.ts
@@ -25,6 +25,7 @@ export interface WalletIdentifier {
 	type: "address" | "publicKey" | "extendedPublicKey" | "username";
 	value: string;
 	method?: "bip39" | "bip44" | "bip49" | "bip84";
+	networkId?: string;
 }
 
 export interface ClientService {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Adds an extra `networkId` field to the `WalletIdentifier` interface which can be used to also match against a wallets network in the transaction aggregate wallet lookup, in addition to the identifier value itself.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
