### PR TITLE
fix: fix currency format for currencies without decimals

### DIFF
--- a/packages/profiles/source/helpers/currency.test.ts
+++ b/packages/profiles/source/helpers/currency.test.ts
@@ -7,6 +7,10 @@ describe("Helpers.Currency", ({ assert, each, it }) => {
 		assert.is(Currency.format(10, "USD"), "$10.00");
 	});
 
+	it("should format fiat without decimals", () => {
+		assert.is(Currency.format(10, "KRW"), "₩10.00");
+	});
+
 	each(
 		"should format crypto (%s)",
 		({ dataset }) => {

--- a/packages/profiles/source/helpers/currency.ts
+++ b/packages/profiles/source/helpers/currency.ts
@@ -29,7 +29,7 @@ export class Currency {
 		}
 
 		let money = Money.make(
-			BigNumber.make(Math.abs(value)).times(Math.pow(10, decimals)).decimalPlaces(0).toNumber(),
+			BigNumber.make(Math.abs(value)).times(Math.pow(10, 2)).decimalPlaces(0).toNumber(),
 			ticker,
 		);
 

--- a/packages/profiles/source/helpers/currency.ts
+++ b/packages/profiles/source/helpers/currency.ts
@@ -29,7 +29,7 @@ export class Currency {
 		}
 
 		let money = Money.make(
-			BigNumber.make(Math.abs(value)).times(Math.pow(10, 2)).decimalPlaces(0).toNumber(),
+			BigNumber.make(Math.abs(value)).times(100).decimalPlaces(0).toNumber(),
 			ticker,
 		);
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Once released and dependency updated on DW should fix https://github.com/ArkEcosystem/payvo-wallet/issues/1357

Instead of passing the decimals now passes a fixed number, no need to make it dynamic since it always needs to be multiplied by 100 (10^2decimals) so it can be formatted as expected


## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
