### PR TITLE
fix(ark): normalize transaction data on broadcast

### DIFF
--- a/packages/ark/source/signed-transaction.dto.ts
+++ b/packages/ark/source/signed-transaction.dto.ts
@@ -104,30 +104,8 @@ export class SignedTransactionData
 	}
 
 	public override toBroadcast() {
-		return this.#normalizeBroadcastData(this.broadcastData);
-	}
-
-	#normalizeBroadcastData<T>(value: Contracts.RawTransactionData): T {
-		return JSON.parse(
-			JSON.stringify(value, (key, value) => {
-				if (typeof value === "bigint") {
-					return value.toString();
-				}
-
-				if (["timestamp"].includes(key)) {
-					return undefined;
-				}
-
-				if (["amount", "nonce", "fee"].includes(key)) {
-					return value.toString();
-				}
-
-				if (value instanceof Map) {
-					return Object.fromEntries(value);
-				}
-
-				return value;
-			}),
-		);
+		const broadcastData = super.normalizeTransactionData<Contracts.RawTransactionData>(this.broadcastData);
+		delete broadcastData.timestamp;
+		return broadcastData;
 	}
 }

--- a/packages/ark/source/signed-transaction.dto.ts
+++ b/packages/ark/source/signed-transaction.dto.ts
@@ -102,4 +102,32 @@ export class SignedTransactionData
 	public override usesMultiSignature(): boolean {
 		return !!this.signedData.multiSignature;
 	}
+
+	public override toBroadcast() {
+		return this.#normalizeBroadcastData(this.broadcastData);
+	}
+
+	#normalizeBroadcastData<T>(value: Contracts.RawTransactionData): T {
+		return JSON.parse(
+			JSON.stringify(value, (key, value) => {
+				if (typeof value === "bigint") {
+					return value.toString();
+				}
+
+				if (["timestamp"].includes(key)) {
+					return undefined;
+				}
+
+				if (["amount", "nonce", "fee"].includes(key)) {
+					return value.toString();
+				}
+
+				if (value instanceof Map) {
+					return Object.fromEntries(value);
+				}
+
+				return value;
+			}),
+		);
+	}
 }

--- a/packages/sdk/source/signed-transaction.dto.ts
+++ b/packages/sdk/source/signed-transaction.dto.ts
@@ -187,11 +187,11 @@ export class AbstractSignedTransactionData implements SignedTransactionData {
 	}
 
 	public toBroadcast(): any {
-		return this.#normalizeTransactionData(this.broadcastData);
+		return this.normalizeTransactionData(this.broadcastData);
 	}
 
 	public toSignedData(): any {
-		return this.#normalizeTransactionData(this.signedData);
+		return this.normalizeTransactionData(this.signedData);
 	}
 
 	public toObject(): SignedTransactionObject {
@@ -232,7 +232,7 @@ export class AbstractSignedTransactionData implements SignedTransactionData {
 		];
 	}
 
-	#normalizeTransactionData<T>(value: RawTransactionData): T {
+	protected normalizeTransactionData<T>(value: RawTransactionData): T {
 		return JSON.parse(
 			JSON.stringify(value, (key, value) => {
 				if (typeof value === "bigint") {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Normalizes transaction data by removing timestamp which is necessary for ark, and throws broadcast exceptions for ark-based coins like compendia.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
