### PR TITLE
fix: removing an element by index removes all items if using zero

### DIFF
--- a/packages/profiles/source/host.repository.test.ts
+++ b/packages/profiles/source/host.repository.test.ts
@@ -91,7 +91,7 @@ describeWithContext(
 
 			context.subject.push({
 				...context.full,
-				name: "another name"
+				name: "another name",
 			});
 
 			assert.length(context.subject.allByNetwork("ark.mainnet"), 2);

--- a/packages/profiles/source/host.repository.test.ts
+++ b/packages/profiles/source/host.repository.test.ts
@@ -89,11 +89,16 @@ describeWithContext(
 
 			context.subject.push(context.full);
 
-			assert.length(context.subject.allByNetwork("ark.mainnet"), 1);
+			context.subject.push({
+				...context.full,
+				name: "another name"
+			});
+
+			assert.length(context.subject.allByNetwork("ark.mainnet"), 2);
 
 			context.subject.forget("ark.mainnet", 0);
 
-			assert.length(context.subject.allByNetwork("ark.mainnet"), 0);
+			assert.length(context.subject.allByNetwork("ark.mainnet"), 1);
 		});
 	},
 );

--- a/packages/profiles/source/host.repository.ts
+++ b/packages/profiles/source/host.repository.ts
@@ -42,7 +42,7 @@ export class HostRepository implements IHostRepository {
 
 	/** {@inheritDoc HostRepository.forget} */
 	public forget(network: string, index?: number): void {
-		if (index) {
+		if (index !== undefined) {
 			this.#data.forgetIndex(network, index);
 		} else {
 			this.#data.forget(network);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Since the check is against a falsy value if I Pass `0` to the forget method it removes all the items



## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
