### PR TITLE
fix(profiles): ensure custom hosts are for the selected type

### DIFF
--- a/packages/profiles/source/driver.ts
+++ b/packages/profiles/source/driver.ts
@@ -23,7 +23,7 @@ export const defaultHostSelector =
 			.hosts()
 			.allByNetwork(configRepository.get("network.id"))
 			.map(({ host }) => host)
-			.filter(({ custom, enabled }) => custom && enabled);
+			.filter(({ custom, enabled, type: hostType }) => custom && enabled && hostType === type);
 
 		if (customHosts.length === 0) {
 			return Helpers.randomHost(defaultHosts, type);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

When getting the custom hosts we should only select the ones for the specific type that was passed, otherwise, it creates a scenario where customHosts.length>1 but there are no really any custom host to get in the random function

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
