### PR TITLE
wip:  register all available coins on profile restoration

### DIFF
--- a/packages/profiles/source/coin.service.contract.ts
+++ b/packages/profiles/source/coin.service.contract.ts
@@ -1,4 +1,4 @@
-import { Coins } from "@payvo/sdk";
+import { Coins, Networks } from "@payvo/sdk";
 
 /**
  * Defines the implementation contract for the coin service.
@@ -79,4 +79,19 @@ export interface ICoinService {
 	 * @memberof ICoinService
 	 */
 	makeInstance(coin: string, network: string, options?: object): Coins.Coin;
+
+	/**
+	 * Register all available coins stored in profile.
+	 *
+	 * @memberof ICoinService
+	 */
+	register(): void;
+
+	/**
+	 * Get all available coin networks.
+	 *
+	 * @return {Networks.Network[]}
+	 * @memberof ICoinService
+	 */
+	availableNetworks(): Networks.Network[];
 }

--- a/packages/profiles/source/profile.contract.ts
+++ b/packages/profiles/source/profile.contract.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { Networks } from "@payvo/sdk";
 import {
 	IAppearanceService,
 	IAuthenticator,
@@ -186,6 +187,14 @@ export interface IProfile {
 	 * @memberof IProfile
 	 */
 	networks(): INetworkRepository;
+
+	/**
+	 * Get all available coin networks stored in profile.
+	 *
+	 * @return {Networks.Network[]}
+	 * @memberof IProfile
+	 */
+	availableNetworks(): Networks.Network[];
 
 	/**
 	 * Get the exchange transactions repository instance.

--- a/packages/profiles/source/profile.importer.ts
+++ b/packages/profiles/source/profile.importer.ts
@@ -44,6 +44,8 @@ export class ProfileImporter implements IProfileImporter {
 
 		this.#profile.settings().fill(data.settings);
 
+		this.#profile.coins().register();
+
 		await this.#profile.wallets().fill(data.wallets);
 
 		await this.#profile.pendingMusigWallets().fill(data.pendingMusigWallets);

--- a/packages/profiles/source/profile.ts
+++ b/packages/profiles/source/profile.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { Networks } from "@payvo/sdk";
 import { AppearanceService } from "./appearance.service.js";
 import { Authenticator } from "./authenticator.js";
 import { CoinService } from "./coin.service.js";
@@ -348,6 +349,11 @@ export class Profile implements IProfile {
 	/** {@inheritDoc IProfile.networks} */
 	public networks(): INetworkRepository {
 		return this.#networkRepository;
+	}
+
+	/** {@inheritDoc IProfile.availableNetworks} */
+	public availableNetworks(): Networks.Network[] {
+		return this.coins().availableNetworks();
 	}
 
 	/** {@inheritDoc IProfile.exchangeTransactions} */


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
This PR enables the use of custom networks. Required in https://github.com/ArkEcosystem/payvo-wallet/pull/1445

- [ ] Implements `IProfile#availableNetworks`. Restore all available network instances based on profile's coins.
- [ ] Implements `IProfile#ICoinService#register`. Register all coins that are available from profile stored networks.
- [ ] Registers all available coins (default or custom) on profile restoration  



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
